### PR TITLE
Fixed typographical error, changed accross to across in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1597,7 +1597,7 @@ Episode List
 	Tumblr blog on empty states
 + [Webshim](http://afarkas.github.io/webshim/demos/index.html#)
 
-	Use HTML5 accross browsers
+	Use HTML5 across browsers
 + [Wirefy](http://getwirefy.com/)
 
 	A simple frontend framework for prototyping


### PR DESCRIPTION
@MHM5000, I've corrected a typographical error in the documentation of the [TreehouseShow](https://github.com/MHM5000/TreehouseShow) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.